### PR TITLE
Make file path in request body relative to the project

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -13,16 +13,16 @@ module.exports =
 
     getSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix, activatedManually}) ->
       deferred = q.defer()
+      projectPath = getOwnerProject(editor.getPath())
+      port = getPortForProject(projectPath)
       body =
-        path: editor.getPath()
+        path: editor.getPath().replace(projectPath + '/', 'res://')
         text: editor.getText()
         cursor: {
           row: bufferPosition['row']
           column: bufferPosition['column']
         }
         meta: ''
-      projectPath = getOwnerProject(editor.getPath())
-      port = getPortForProject(projectPath)
       request {
         method: 'POST',
         uri: 'http://localhost:' + (port ? 6070),


### PR DESCRIPTION
The [code_completion_service.cpp](https://github.com/neikeq/gd-autocomplete-service/blob/master/autocomplete_service/code_completion_service.cpp#L28) seems to expect a relative path:

```cpp
if (path == "res://" || !path.begins_with("res://"))
	return Result();
```
Without this change the server was always responding with a 404 status and the autocompletion didn't work.